### PR TITLE
Changed isinside() parameter order to be consistent convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ true
 
 Finally, we can see if a bounds is inside another one:
 ```
-julia> isinside(Bounds2(3,3,0,0), Bounds2(2,2,1,1))
+julia> isinside(Bounds2(2,2,1,1), Bounds2(3,3,0,0))
 true
 
-julia> isinside(Bounds2(3,3,0,0), Bounds2(2,2,-1,-1))
+julia> isinside(Bounds2(2,2,-1,-1), Bounds2(3,3,0,0))
 false
 ```
 

--- a/src/BoundingBoxes.jl
+++ b/src/BoundingBoxes.jl
@@ -46,13 +46,13 @@ macro boundingbox(ex)
     update_block = Expr(:block, update_body..., :(return nothing))
     update_bounds = Expr(:function, update_args, update_block)
 
-    # construct isinside (b isinside a)
+    # construct isinside (a isinside b)
     isinside_eqs = [Expr(:call, :(>),
-                 dots("a", "_max", axe),
-                 dots("b", "_max", axe)) for axe in axes]
+                 dots("b", "_max", axe),
+                 dots("a", "_max", axe)) for axe in axes]
     append!(isinside_eqs, [Expr(:call, :(<),
-                 dots("a", "_min", axe),
-                 dots("b", "_min", axe)) for axe in axes])
+                 dots("b", "_min", axe),
+                 dots("a", "_min", axe)) for axe in axes])
     isinside_return = Expr(:return, andlist(isinside_eqs))
     isinside_block = Expr(:block, isinside_return)
     isinside_args = :(isinside(a::$(bound_name), b::$(bound_name)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,8 +52,8 @@ update!(bb3a, [4,5,6])
 @test bb3a.z_min == 3
 
 # test isinside
-bb3a = Bounds3{Float64}(1,1,1,0,0,0)
-bb3b = Bounds3{Float64}(0.5,0.5,0.5,0.25,0.25,0.25)
+bb3a = Bounds3{Float64}(0.5,0.5,0.5,0.25,0.25,0.25)
+bb3b = Bounds3{Float64}(1,1,1,0,0,0)
 @test isinside(bb3a,bb3b)
 @test !isinside(bb3b,bb3a)
 


### PR DESCRIPTION
Note: this is a breaking change.  We should bump the major version.